### PR TITLE
Align gallery dividers and padding with list tiles

### DIFF
--- a/lib/home_components/contrib_card.dart
+++ b/lib/home_components/contrib_card.dart
@@ -54,7 +54,10 @@ class ContribCard extends StatelessWidget {
             style: Theme.of(context).textTheme.titleMedium!,
           ),
         ),
-        const Divider(indent: 10),
+        Divider(
+          indent:
+              Theme.of(context).listTileTheme.contentPadding?.left ?? 16,
+        ),
         const ContribListTile(
           projectName: "k2-fsa/icefall",
           projectUrl: "https://github.com/k2-fsa/icefall",

--- a/lib/home_components/polaroid_card.dart
+++ b/lib/home_components/polaroid_card.dart
@@ -28,11 +28,14 @@ class PolaroidCard extends StatelessWidget {
               style: Theme.of(context).textTheme.titleMedium!,
             ),
           ),
-          const Divider(indent: 10),
+          Divider(
+            indent:
+                Theme.of(context).listTileTheme.contentPadding?.left ?? 16,
+          ),
           Container(
             width: double.maxFinite,
             height: 400,
-            padding: const EdgeInsets.all(10),
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
             child: CarouselView.weighted(
               controller: CarouselController(initialItem: 1),
               itemSnapping: true,

--- a/lib/home_components/selected_pub_card.dart
+++ b/lib/home_components/selected_pub_card.dart
@@ -26,7 +26,10 @@ class _SelectedPubCardState extends State<SelectedPubCard>
               style: Theme.of(context).textTheme.titleMedium!,
             ),
           ),
-          const Divider(indent: 10),
+          Divider(
+            indent:
+                Theme.of(context).listTileTheme.contentPadding?.left ?? 16,
+          ),
           // AnimatedSize wraps the dynamic area so the card expansion animates smoothly
           AnimatedSize(
             duration: const Duration(milliseconds: 300),


### PR DESCRIPTION
## Summary
- align the dividers in the contribution, publications, and polaroid cards with the surrounding list tile content padding
- update the polaroid gallery container spacing to use Material scale values for consistent layout

## Testing
- flutter analyze *(fails: Flutter SDK not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf39cd7a6c833088ec0feda0482694