### PR TITLE
Adjust text padding in cards

### DIFF
--- a/lib/home_components/polaroid_card.dart
+++ b/lib/home_components/polaroid_card.dart
@@ -45,9 +45,11 @@ class PolaroidCard extends StatelessWidget {
                   .toList(),
             ),
           ),
-          const ListTile(
-            title: Text(
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+            child: Text(
               "I have one Polaroid Spectra for shooting B&W film, one SX-70 Sonar, and one SLR680 for regular shooting. My Polaroid camera collection also includes an SLR680 Special Edition (Blue Button Version), an SX-70 Model 2, a 670-AF, and a 670-AF Special Edition (also known as the Blue Button Version).",
+              style: Theme.of(context).textTheme.bodyMedium!,
             ),
           ),
         ],

--- a/lib/home_components/self_intro_card.dart
+++ b/lib/home_components/self_intro_card.dart
@@ -23,7 +23,10 @@ class IntroductionCard extends StatelessWidget {
             ),
             subtitle: const Text("金增锐"),
           ),
-          ListTile(title: const MyIntroduction()),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: MyIntroduction(),
+          ),
           ListTile(
             leading: const Icon(Icons.email),
             title: Text(


### PR DESCRIPTION
## Summary
- replace the long-text list tile in the introduction card with padded content so the paragraph can size naturally
- convert the polaroid description to padded body text that uses the theme typography instead of a list tile

## Testing
- flutter analyze *(fails: flutter is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf39cb378c8330bbc6082455a03151