### PR TITLE
Adjust link button hierarchy

### DIFF
--- a/lib/utilities/link_buttonbar.dart
+++ b/lib/utilities/link_buttonbar.dart
@@ -6,21 +6,24 @@ final linkButtonBar = Padding(
   padding: const EdgeInsets.all(8.0),
   child: OverflowBar(
     alignment: MainAxisAlignment.end,
+    overflowAlignment: OverflowBarAlignment.end,
+    spacing: 8,
+    overflowSpacing: 8,
     children: [
-      TextButton(
-        child: const Text("GitHub"),
-        onPressed: () => launchURL("https://github.com/JinZr"),
-      ),
-      TextButton(
-        child: const Text("ResearchGate"),
-        onPressed: () =>
-            launchURL("https://www.researchgate.net/profile/Zengrui-Jin"),
-      ),
-      FilledButton(
-        child: const Text("Google Scholar"),
+      FilledButton.tonal(
         onPressed: () => launchURL(
           'https://scholar.google.com/citations?user=kgH1mk0AAAAJ&hl=en',
         ),
+        child: const Text('Google Scholar'),
+      ),
+      TextButton(
+        onPressed: () => launchURL('https://github.com/JinZr'),
+        child: const Text('GitHub'),
+      ),
+      TextButton(
+        onPressed: () =>
+            launchURL('https://www.researchgate.net/profile/Zengrui-Jin'),
+        child: const Text('ResearchGate'),
       ),
     ],
   ),


### PR DESCRIPTION
## Summary
- emphasize the Google Scholar link as the primary action with a tonal filled button
- keep the remaining links as text buttons while adding spacing controls so the bar wraps neatly on narrow layouts

## Testing
- flutter test *(fails: `flutter` command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf39c779348330a1855d3504511e43