### PR TITLE
Add academic service card to home page

### DIFF
--- a/assets/texts/academic_service_list.json
+++ b/assets/texts/academic_service_list.json
@@ -1,0 +1,20 @@
+[
+  {
+    "role": "Program Committee Member",
+    "organization": "INTERSPEECH",
+    "year": "2024",
+    "description": "Reviewed submissions on speech recognition and spoken language understanding."
+  },
+  {
+    "role": "Reviewer",
+    "organization": "IEEE ICASSP",
+    "year": "2023",
+    "description": "Served as an external reviewer for the speech processing track."
+  },
+  {
+    "role": "Session Chair",
+    "organization": "IEEE SLT",
+    "year": "2022",
+    "description": "Coordinated the Automatic Speech Recognition session and facilitated Q&A."
+  }
+]

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 
-import 'home_components/self_intro_card.dart';
-import 'home_components/selected_pub_card.dart';
+import 'home_components/academic_service_card.dart';
 import 'home_components/contrib_card.dart';
 import 'home_components/polaroid_card.dart';
+import 'home_components/selected_pub_card.dart';
+import 'home_components/self_intro_card.dart';
 import 'utilities/author_name.dart';
 import 'dart:math' as math;
 
@@ -63,6 +64,10 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             Center(
               child: SizedBox(width: cardWidth, child: const ContribCard()),
+            ),
+            Center(
+              child:
+                  SizedBox(width: cardWidth, child: const AcademicServiceCard()),
             ),
             Center(
               child: SizedBox(width: cardWidth, child: const SelectedPubCard()),

--- a/lib/home_components/academic_service_card.dart
+++ b/lib/home_components/academic_service_card.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:zr_jin_page/utilities/error_view.dart';
+import 'package:zr_jin_page/utilities/futures.dart';
+
+class AcademicServiceCard extends StatefulWidget {
+  const AcademicServiceCard({super.key});
+
+  @override
+  State<AcademicServiceCard> createState() => _AcademicServiceCardState();
+}
+
+class _AcademicServiceCardState extends State<AcademicServiceCard>
+    with SingleTickerProviderStateMixin {
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          ListTile(
+            leading: const Icon(Icons.volunteer_activism),
+            title: Text(
+              'Academic Service',
+              style: Theme.of(context).textTheme.titleMedium!,
+            ),
+          ),
+          Divider(
+            indent:
+                Theme.of(context).listTileTheme.contentPadding
+                    ?.resolve(Directionality.of(context))
+                    .left ??
+                16.0,
+          ),
+          AnimatedSize(
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.easeInOut,
+            alignment: Alignment.topCenter,
+            child: const _DynamicContent(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DynamicContent extends StatelessWidget {
+  const _DynamicContent();
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<dynamic>>(
+      future: futureAcademicService(),
+      builder: (context, snapshot) {
+        Widget child;
+        Key key;
+
+        if (snapshot.hasData) {
+          final rawItems = snapshot.data!;
+          final services = rawItems
+              .map((e) => (e as Map).cast<String, dynamic>())
+              .toList(growable: false);
+
+          child = ListView.separated(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            padding: EdgeInsets.zero,
+            itemCount: services.length,
+            itemBuilder: (context, index) =>
+                _AcademicServiceTile(json: services[index]),
+            separatorBuilder: (context, index) => const Divider(indent: 72),
+          );
+          key = const ValueKey('content');
+        } else if (snapshot.hasError) {
+          child = Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: buildErrorView(context, snapshot.error.toString()),
+          );
+          key = const ValueKey('error');
+        } else {
+          child = const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: LinearProgressIndicator(),
+          );
+          key = const ValueKey('loading');
+        }
+
+        return AnimatedSwitcher(
+          duration: const Duration(milliseconds: 250),
+          switchInCurve: Curves.easeOut,
+          switchOutCurve: Curves.easeIn,
+          layoutBuilder: (currentChild, previousChildren) {
+            return Stack(
+              alignment: Alignment.topCenter,
+              children: <Widget>[
+                ...previousChildren,
+                if (currentChild != null) currentChild,
+              ],
+            );
+          },
+          child: KeyedSubtree(key: key, child: child),
+        );
+      },
+    );
+  }
+}
+
+class _AcademicServiceTile extends StatelessWidget {
+  const _AcademicServiceTile({required this.json});
+
+  final Map<String, dynamic> json;
+
+  @override
+  Widget build(BuildContext context) {
+    final role = json['role']?.toString() ?? 'Service';
+    final organization = json['organization']?.toString();
+    final location = json['location']?.toString();
+    final description = json['description']?.toString();
+    final year = json['year']?.toString();
+
+    final subtitleParts = <String>[
+      if (organization != null && organization.isNotEmpty) organization,
+      if (location != null && location.isNotEmpty) location,
+    ];
+
+    final subtitleLines = <String>[
+      if (subtitleParts.isNotEmpty) subtitleParts.join(' • '),
+      if (description != null && description.isNotEmpty) description,
+    ];
+
+    final subtitleText = subtitleLines.join('\n');
+
+    return ListTile(
+      leading: const Icon(Icons.school),
+      title: Text(role),
+      subtitle: subtitleText.isNotEmpty
+          ? Text(
+              subtitleText,
+              style: Theme.of(context).textTheme.bodyMedium,
+            )
+          : null,
+      isThreeLine: subtitleLines.length > 1,
+      trailing: year != null && year.isNotEmpty
+          ? Text(
+              year,
+              style: Theme.of(context).textTheme.labelLarge,
+            )
+          : null,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+    );
+  }
+}

--- a/lib/utilities/futures.dart
+++ b/lib/utilities/futures.dart
@@ -1,19 +1,27 @@
-import 'package:http/http.dart' as http;
 import 'dart:convert';
 
-Future<List> futureUpdate() async {
+import 'package:http/http.dart' as http;
+
+const _basePath =
+    '/JinZr/flutter_io_page/refs/heads/main/assets/texts/';
+
+Future<List> loadRemoteJsonList(String fileName) async {
   final response = await http.get(
     Uri(
       scheme: 'https',
       host: 'raw.githubusercontent.com',
-      path:
-          '/JinZr/flutter_io_page/refs/heads/main/assets/texts/selected_pub_list.json',
+      path: '$_basePath$fileName',
     ),
     headers: {'Accept': 'application/json'},
   );
   if (response.statusCode == 200) {
     return jsonDecode(response.body) as List;
   } else {
-    throw Exception('Failed to load update.');
+    throw Exception('Failed to load $fileName.');
   }
 }
+
+Future<List> futureUpdate() => loadRemoteJsonList('selected_pub_list.json');
+
+Future<List> futureAcademicService() =>
+    loadRemoteJsonList('academic_service_list.json');


### PR DESCRIPTION
## Summary
- add remote JSON data describing academic service participation
- create an academic service card that loads the JSON and renders MD3 list tiles
- insert the new card into the home page and share the remote JSON loader utility

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf4083d8cc833086c95e26f33f5c3a