### PR TITLE
Add staggered entrance animation to home cards

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'home_components/academic_service_card.dart';
+import 'home_components/card_entrance_wrapper.dart';
 import 'home_components/contrib_card.dart';
 import 'home_components/polaroid_card.dart';
 import 'home_components/selected_pub_card.dart';
@@ -24,6 +25,15 @@ class _MyHomePageState extends State<MyHomePage> {
     // var screenWidth = MediaQuery.sizeOf(context).width;
     final screenWidth = MediaQuery.sizeOf(context).width;
     final cardWidth = math.min(screenWidth, 1200.0);
+
+    Widget animatedCard({required Widget child, required int index}) {
+      return Center(
+        child: HomeCardEntrance(
+          delay: Duration(milliseconds: 120 * index),
+          child: SizedBox(width: cardWidth, child: child),
+        ),
+      );
+    }
 
     return Scaffold(
       body: NestedScrollView(
@@ -56,27 +66,11 @@ class _MyHomePageState extends State<MyHomePage> {
             ],
         body: ListView(
           children: [
-            Center(
-              child: SizedBox(
-                width: cardWidth,
-                child: const IntroductionCard(),
-              ),
-            ),
-            Center(
-              child: SizedBox(width: cardWidth, child: const SelectedPubCard()),
-            ),
-            Center(
-              child: SizedBox(width: cardWidth, child: const ContribCard()),
-            ),
-            Center(
-              child: SizedBox(
-                width: cardWidth,
-                child: const AcademicServiceCard(),
-              ),
-            ),
-            Center(
-              child: SizedBox(width: cardWidth, child: const PolaroidCard()),
-            ),
+            animatedCard(child: const IntroductionCard(), index: 0),
+            animatedCard(child: const SelectedPubCard(), index: 1),
+            animatedCard(child: const ContribCard(), index: 2),
+            animatedCard(child: const AcademicServiceCard(), index: 3),
+            animatedCard(child: const PolaroidCard(), index: 4),
           ],
         ),
       ),

--- a/lib/home_components/card_entrance_wrapper.dart
+++ b/lib/home_components/card_entrance_wrapper.dart
@@ -1,0 +1,79 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+class HomeCardEntrance extends StatefulWidget {
+  const HomeCardEntrance({
+    super.key,
+    required this.child,
+    this.delay = Duration.zero,
+    this.duration = const Duration(milliseconds: 450),
+    this.initialOffset = 0.08,
+  });
+
+  final Widget child;
+  final Duration delay;
+  final Duration duration;
+  final double initialOffset;
+
+  @override
+  State<HomeCardEntrance> createState() => _HomeCardEntranceState();
+}
+
+class _HomeCardEntranceState extends State<HomeCardEntrance>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _fade;
+  late final Animation<Offset> _slide;
+  Timer? _delayTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: widget.duration,
+    );
+    _fade = CurvedAnimation(
+      parent: _controller,
+      curve: Curves.easeOutCubic,
+    );
+    _slide = Tween<Offset>(
+      begin: Offset(0, widget.initialOffset),
+      end: Offset.zero,
+    ).animate(
+      CurvedAnimation(
+        parent: _controller,
+        curve: Curves.easeOutCubic,
+      ),
+    );
+
+    if (widget.delay == Duration.zero) {
+      _controller.forward();
+    } else {
+      _delayTimer = Timer(widget.delay, () {
+        if (mounted && _controller.status == AnimationStatus.dismissed) {
+          _controller.forward();
+        }
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _delayTimer?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FadeTransition(
+      opacity: _fade,
+      child: SlideTransition(
+        position: _slide,
+        child: widget.child,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable `HomeCardEntrance` widget that animates cards with a slide and fade
- wrap each home page card with the new animation to provide a staggered entrance effect

## Testing
- Not run (flutter not installed in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc1159a3908330a20520c8c95ded5d