### PR TITLE
Replace deprecated dart:html usage with package:web

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,10 +4,12 @@ import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:zr_jin_page/utilities/author_name.dart';
 import 'theme/theme.dart';
 import 'theme/util.dart';
+import 'utilities/browser_navigation.dart';
 
 import 'home.dart';
 
 void main() {
+  disableBrowserNavigation();
   setUrlStrategy(PathUrlStrategy());
 
   runApp(const MyApp());

--- a/lib/utilities/browser_navigation.dart
+++ b/lib/utilities/browser_navigation.dart
@@ -1,0 +1,5 @@
+import 'browser_navigation_stub.dart'
+    if (dart.library.html) 'browser_navigation_web.dart';
+
+/// Disables browser back/forward navigation gestures when running on the web.
+void disableBrowserNavigation() => disableBrowserNavigationImpl();

--- a/lib/utilities/browser_navigation_stub.dart
+++ b/lib/utilities/browser_navigation_stub.dart
@@ -1,0 +1,1 @@
+void disableBrowserNavigationImpl() {}

--- a/lib/utilities/browser_navigation_web.dart
+++ b/lib/utilities/browser_navigation_web.dart
@@ -1,0 +1,43 @@
+import 'package:web/web.dart' as web;
+
+void disableBrowserNavigationImpl() {
+  void _pushState() {
+    final currentUrl = web.window.location.href;
+    web.window.history.pushState(null, '', currentUrl);
+  }
+
+  web.document.documentElement
+      ?.style
+      .setProperty('overscroll-behavior-x', 'none');
+  web.document.body?.style.setProperty('overscroll-behavior-x', 'none');
+
+  // Ensure there is a history entry so that navigating back immediately
+  // triggers our popstate handler instead of leaving the page.
+  _pushState();
+
+  web.window.addEventListener('popstate', (_) {
+    _pushState();
+  });
+
+  web.document.addEventListener('keydown', (event) {
+    if (event is! web.KeyboardEvent) {
+      return;
+    }
+
+    final key = event.key?.toLowerCase();
+    if (key == null) {
+      return;
+    }
+
+    final isAltArrowNavigation =
+        event.altKey && (key == 'arrowleft' || key == 'arrowright');
+    final isBrowserNavigationKey = key == 'browserback' ||
+        key == 'browserforward' ||
+        key == 'goback' ||
+        key == 'goforward';
+
+    if (isAltArrowNavigation || isBrowserNavigationKey) {
+      event.preventDefault();
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- replace dart:html usage in the web navigation blocker with package:web DOM APIs to avoid deprecated imports
- keep the existing navigation gesture suppression logic intact using addEventListener and typed KeyboardEvents

## Testing
- not run (environment lacks Flutter/Dart tooling)


------
https://chatgpt.com/codex/tasks/task_e_68dc15c834808330a3e38be372813624