### PR TITLE
Optimize Flutter web performance pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,39 @@
-# io_page
+# Flutter IO Page
 
-A new Flutter project.
+Static personal homepage implemented in Flutter Web.
 
-## Getting Started
+## Building for Web
 
-This project is a starting point for a Flutter application.
+```bash
+./build.sh
+```
 
-A few resources to get you started if this is your first Flutter project:
+The build script enforces the HTML renderer, offline-first service worker, and
+size analysis with symbol splitting. Release output is written to the default
+`build/web` folder (or `build/web-html` when using `tool/perf_measure.sh`).
 
-- [Lab: Write your first Flutter app](https://flutter.dev/docs/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://flutter.dev/docs/cookbook)
+### Recommended profiling workflow
 
-For help getting started with Flutter, view our
-[online documentation](https://flutter.dev/docs), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+1. Ensure a recent stable Flutter SDK is installed and on your `PATH`.
+2. Run the helper script to rebuild and capture bundle size reports:
+
+   ```bash
+   tool/perf_measure.sh
+   ```
+
+3. Serve the release build and collect Lighthouse metrics:
+
+   ```bash
+   flutter run -d web-server --web-hostname 127.0.0.1 --web-port 8080 --release --web-renderer html
+   # In another terminal run Lighthouse against http://127.0.0.1:8080
+   ```
+
+4. Save the Lighthouse JSON/HTML and FPS captures under `perf/before/` or
+   `perf/after/`.
+
+### Asset caching
+
+Structured data (academic services, publications) is bundled in
+`assets/texts/`. The widgets hydrate with the local snapshot immediately and
+refresh from the GitHub raw endpoint in the background when a network
+connection is available.

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,13 @@
-#!/bin/bash
-# FILEPATH: /Users/zengruijin/Github Project/flutter_io_page/io_page/build.sh
+#!/usr/bin/env bash
+set -euo pipefail
+
 flutter build web \
-    --release \
-    --pwa-strategy none \
-    --optimization-level 4 
+  --release \
+  --web-renderer html \
+  --pwa-strategy offline-first \
+  --source-maps \
+  --split-debug-info=perf/symbols \
+  --tree-shake-icons \
+  --analyze-size \
+  --dart-define=FLUTTER_WEB_AUTO_DETECT=false
 

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -1,14 +1,19 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-import 'home_components/academic_service_card.dart';
+import 'dart:math' as math;
+
+import 'package:flutter/scheduler.dart';
+
+import 'home_components/academic_service_card.dart' deferred as academic_service;
 import 'home_components/card_entrance_wrapper.dart';
-import 'home_components/contrib_card.dart';
-import 'home_components/polaroid_card.dart';
-import 'home_components/selected_pub_card.dart';
+import 'home_components/card_placeholder.dart';
+import 'home_components/contrib_card.dart' deferred as contrib;
+import 'home_components/polaroid_card.dart' deferred as polaroid;
+import 'home_components/selected_pub_card.dart' deferred as selected_pub;
 import 'home_components/self_intro_card.dart';
 import 'utilities/author_name.dart';
-import 'dart:math' as math;
+import 'utilities/deferred_widget.dart';
 
 class MyHomePage extends StatefulWidget {
   const MyHomePage({super.key, required this.titleEn, required this.titleZh});
@@ -21,6 +26,23 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
+  late final List<Future<void> Function()> _deferredLoaders = <Future<void> Function()>[
+    selected_pub.loadLibrary,
+    academic_service.loadLibrary,
+    contrib.loadLibrary,
+    polaroid.loadLibrary,
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      for (final loader in _deferredLoaders) {
+        loader();
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     // var screenWidth = MediaQuery.sizeOf(context).width;
@@ -31,7 +53,9 @@ class _MyHomePageState extends State<MyHomePage> {
       return Center(
         child: HomeCardEntrance(
           delay: Duration(milliseconds: 120 * index),
-          child: SizedBox(width: cardWidth, child: child),
+          child: RepaintBoundary(
+            child: SizedBox(width: cardWidth, child: child),
+          ),
         ),
       );
     }
@@ -86,11 +110,13 @@ class _MyHomePageState extends State<MyHomePage> {
                               begin: Alignment.topCenter,
                               end: Alignment.bottomCenter,
                               colors: [
-                                Theme.of(context).colorScheme.surfaceTint
-                                    .withValues(alpha: 0.35),
+                                Theme.of(context)
+                                    .colorScheme
+                                    .surfaceTint
+                                    .withOpacity(0.35),
                                 Theme.of(
                                   context,
-                                ).colorScheme.surface.withValues(alpha: 0.85),
+                                ).colorScheme.surface.withOpacity(0.85),
                               ],
                             ),
                           ),
@@ -103,10 +129,38 @@ class _MyHomePageState extends State<MyHomePage> {
           body: ListView(
             children: [
               animatedCard(child: const IntroductionCard(), index: 0),
-              animatedCard(child: const SelectedPubCard(), index: 1),
-              animatedCard(child: const ContribCard(), index: 2),
-              animatedCard(child: const AcademicServiceCard(), index: 3),
-              animatedCard(child: const PolaroidCard(), index: 4),
+              animatedCard(
+                child: DeferredWidget(
+                  libraryLoader: selected_pub.loadLibrary,
+                  placeholder: const CardPlaceholder(minHeight: 220),
+                  builder: (_) => selected_pub.SelectedPubCard(),
+                ),
+                index: 1,
+              ),
+              animatedCard(
+                child: DeferredWidget(
+                  libraryLoader: contrib.loadLibrary,
+                  placeholder: const CardPlaceholder(minHeight: 220),
+                  builder: (_) => contrib.ContribCard(),
+                ),
+                index: 2,
+              ),
+              animatedCard(
+                child: DeferredWidget(
+                  libraryLoader: academic_service.loadLibrary,
+                  placeholder: const CardPlaceholder(minHeight: 220),
+                  builder: (_) => academic_service.AcademicServiceCard(),
+                ),
+                index: 3,
+              ),
+              animatedCard(
+                child: DeferredWidget(
+                  libraryLoader: polaroid.loadLibrary,
+                  placeholder: const CardPlaceholder(minHeight: 320),
+                  builder: (_) => polaroid.PolaroidCard(),
+                ),
+                index: 4,
+              ),
             ],
           ),
         ),

--- a/lib/home_components/academic_service_card.dart
+++ b/lib/home_components/academic_service_card.dart
@@ -1,8 +1,9 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:zr_jin_page/utilities/content_repository.dart';
 import 'package:zr_jin_page/utilities/error_view.dart';
 import 'package:zr_jin_page/utilities/futures.dart';
-
-import 'package:url_launcher/url_launcher.dart';
 
 class AcademicServiceCard extends StatefulWidget {
   const AcademicServiceCard({super.key});
@@ -12,9 +13,59 @@ class AcademicServiceCard extends StatefulWidget {
 }
 
 class _AcademicServiceCardState extends State<AcademicServiceCard>
-    with SingleTickerProviderStateMixin {
+    with AutomaticKeepAliveClientMixin {
+  List<Map<String, dynamic>>? _services;
+  Object? _error;
+  late final ContentRepository _repository = ContentRepository.instance;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadContent();
+  }
+
+  Future<void> _loadContent() async {
+    try {
+      final local = await loadCachedJsonList('academic_service_list.json');
+      final mapped = _map(local);
+      if (mounted) {
+        setState(() {
+          _services = mapped;
+          _error = null;
+        });
+      }
+    } catch (error) {
+      if (mounted) {
+        setState(() {
+          _error = error;
+        });
+      }
+    }
+
+    try {
+      final remote = await _repository.loadRemoteList('academic_service_list.json');
+      final mapped = _map(remote);
+      if (mounted && !_listEquals(mapped, _services)) {
+        setState(() {
+          _services = mapped;
+          _error = null;
+        });
+      }
+    } catch (error) {
+      if (mounted && _services == null) {
+        setState(() {
+          _error = error;
+        });
+      }
+    }
+  }
+
+  @override
+  bool get wantKeepAlive => true;
+
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     return Card(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -37,71 +88,75 @@ class _AcademicServiceCardState extends State<AcademicServiceCard>
             duration: const Duration(milliseconds: 300),
             curve: Curves.easeInOut,
             alignment: Alignment.topCenter,
-            child: const _DynamicContent(),
+            child: RepaintBoundary(child: _buildDynamicArea(context)),
           ),
         ],
       ),
     );
   }
-}
 
-class _DynamicContent extends StatelessWidget {
-  const _DynamicContent();
+  Widget _buildDynamicArea(BuildContext context) {
+    Widget child;
+    Key key;
 
-  @override
-  Widget build(BuildContext context) {
-    return FutureBuilder<List<dynamic>>(
-      future: futureAcademicService(),
-      builder: (context, snapshot) {
-        Widget child;
-        Key key;
+    final services = _services;
+    if (services != null) {
+      child = ListView.builder(
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
+        padding: EdgeInsets.zero,
+        itemCount: services.length,
+        itemBuilder: (context, index) =>
+            _AcademicServiceTile(json: services[index]),
+      );
+      key = const ValueKey('content');
+    } else if (_error != null) {
+      child = Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: buildErrorView(context, _error.toString()),
+      );
+      key = const ValueKey('error');
+    } else {
+      child = const Padding(
+        padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: LinearProgressIndicator(),
+      );
+      key = const ValueKey('loading');
+    }
 
-        if (snapshot.hasData) {
-          final rawItems = snapshot.data!;
-          final services = rawItems
-              .map((e) => (e as Map).cast<String, dynamic>())
-              .toList(growable: false);
-
-          child = ListView.builder(
-            shrinkWrap: true,
-            physics: const NeverScrollableScrollPhysics(),
-            padding: EdgeInsets.zero,
-            itemCount: services.length,
-            itemBuilder: (context, index) =>
-                _AcademicServiceTile(json: services[index]),
-          );
-          key = const ValueKey('content');
-        } else if (snapshot.hasError) {
-          child = Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: buildErrorView(context, snapshot.error.toString()),
-          );
-          key = const ValueKey('error');
-        } else {
-          child = const Padding(
-            padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: LinearProgressIndicator(),
-          );
-          key = const ValueKey('loading');
-        }
-
-        return AnimatedSwitcher(
-          duration: const Duration(milliseconds: 250),
-          switchInCurve: Curves.easeOut,
-          switchOutCurve: Curves.easeIn,
-          layoutBuilder: (currentChild, previousChildren) {
-            return Stack(
-              alignment: Alignment.topCenter,
-              children: <Widget>[
-                ...previousChildren,
-                if (currentChild != null) currentChild,
-              ],
-            );
-          },
-          child: KeyedSubtree(key: key, child: child),
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 250),
+      switchInCurve: Curves.easeOut,
+      switchOutCurve: Curves.easeIn,
+      layoutBuilder: (currentChild, previousChildren) {
+        return Stack(
+          alignment: Alignment.topCenter,
+          children: <Widget>[
+            ...previousChildren,
+            if (currentChild != null) currentChild,
+          ],
         );
       },
+      child: KeyedSubtree(key: key, child: child),
     );
+  }
+
+  static List<Map<String, dynamic>> _map(List<dynamic> input) {
+    return input
+        .map((e) => (e as Map).cast<String, dynamic>())
+        .toList(growable: false);
+  }
+
+  static bool _listEquals(
+    List<Map<String, dynamic>>? a,
+    List<Map<String, dynamic>>? b,
+  ) {
+    if (identical(a, b)) return true;
+    if (a == null || b == null || a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (!mapEquals(a[i], b[i])) return false;
+    }
+    return true;
   }
 }
 
@@ -123,7 +178,7 @@ class _AcademicServiceTile extends StatelessWidget {
     ];
 
     final subtitleLines = <String>[
-      if (subtitleParts.isNotEmpty) subtitleParts.join(' • '),
+      if (subtitleParts.isNotEmpty) subtitleParts.join('  '),
     ];
 
     final subtitleText = subtitleLines.join('\n');

--- a/lib/home_components/card_placeholder.dart
+++ b/lib/home_components/card_placeholder.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+class CardPlaceholder extends StatelessWidget {
+  const CardPlaceholder({super.key, this.minHeight = 160});
+
+  final double minHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.surfaceContainerHighest;
+    return Card(
+      clipBehavior: Clip.hardEdge,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(minHeight: minHeight),
+        child: Ink(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: [
+                color.withOpacity(0.35),
+                color.withOpacity(0.15),
+              ],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+          ),
+          child: const Center(
+            child: Padding(
+              padding: EdgeInsets.all(24),
+              child: SizedBox(
+                width: 32,
+                height: 32,
+                child: CircularProgressIndicator(strokeWidth: 2.6),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+import 'package:google_fonts/google_fonts.dart';
 
 import 'package:zr_jin_page/utilities/author_name.dart';
 import 'theme/theme.dart';
@@ -8,6 +9,8 @@ import 'theme/util.dart';
 import 'home.dart';
 
 void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  GoogleFonts.config.allowRuntimeFetching = false;
   setUrlStrategy(PathUrlStrategy());
 
   runApp(const MyApp());

--- a/lib/utilities/content_repository.dart
+++ b/lib/utilities/content_repository.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:http/http.dart' as http;
+
+class ContentRepository {
+  ContentRepository({http.Client? client}) : _client = client ?? http.Client();
+
+  final http.Client _client;
+  final Map<String, List<dynamic>> _localCache = {};
+  final Map<String, List<dynamic>> _remoteCache = {};
+  final Map<String, Future<List<dynamic>>> _remoteInFlight = {};
+
+  static final ContentRepository instance = ContentRepository();
+
+  static const String _basePath =
+      '/JinZr/flutter_io_page/refs/heads/main/assets/texts/';
+
+  Future<List<dynamic>> loadLocalList(String fileName) async {
+    if (_localCache.containsKey(fileName)) {
+      return _localCache[fileName]!;
+    }
+    final assetPath = 'assets/texts/$fileName';
+    try {
+      final jsonString = await rootBundle.loadString(assetPath);
+      final data = jsonDecode(jsonString) as List<dynamic>;
+      _localCache[fileName] = data;
+      return data;
+    } on FlutterError catch (error) {
+      throw StateError('Missing bundled asset: $assetPath\n$error');
+    }
+  }
+
+  Future<List<dynamic>> loadRemoteList(String fileName,
+      {Duration timeout = const Duration(seconds: 4)}) {
+    if (_remoteCache.containsKey(fileName)) {
+      return Future.value(_remoteCache[fileName]!);
+    }
+
+    return _remoteInFlight.putIfAbsent(fileName, () async {
+      final uri = Uri(
+        scheme: 'https',
+        host: 'raw.githubusercontent.com',
+        path: '$_basePath$fileName',
+      );
+
+      final response = await _client
+          .get(uri, headers: const {'Accept': 'application/json'})
+          .timeout(timeout);
+
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body) as List<dynamic>;
+        _remoteCache[fileName] = data;
+        return data;
+      }
+      throw Exception('Failed to load $fileName: ${response.statusCode}');
+    });
+  }
+}

--- a/lib/utilities/deferred_widget.dart
+++ b/lib/utilities/deferred_widget.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+class DeferredWidget extends StatefulWidget {
+  const DeferredWidget({
+    super.key,
+    required this.libraryLoader,
+    required this.builder,
+    this.placeholder,
+  });
+
+  final Future<void> Function() libraryLoader;
+  final WidgetBuilder builder;
+  final Widget? placeholder;
+
+  @override
+  State<DeferredWidget> createState() => _DeferredWidgetState();
+}
+
+class _DeferredWidgetState extends State<DeferredWidget> {
+  late final Future<void> _loadFuture = widget.libraryLoader();
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<void>(
+      future: _loadFuture,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.done) {
+          return widget.builder(context);
+        }
+        return widget.placeholder ?? const SizedBox.shrink();
+      },
+    );
+  }
+}

--- a/perf/README.md
+++ b/perf/README.md
@@ -1,0 +1,6 @@
+# Performance Reports
+
+- Place baseline measurements under `perf/before/`.
+- Place optimized measurements under `perf/after/`.
+- Store code size outputs from `flutter build web --analyze-size` inside the respective `size/` directories.
+- Lighthouse JSON/HTML exports should be named `lighthouse-<metric>.json` (or `.html`).

--- a/perf/after/README.md
+++ b/perf/after/README.md
@@ -1,0 +1,2 @@
+Optimised build metrics should be copied here together with Lighthouse reports
+and code size outputs.

--- a/perf/after/report-template.md
+++ b/perf/after/report-template.md
@@ -1,0 +1,10 @@
+| Metric | Before | After | Delta | Notes |
+| --- | --- | --- | --- | --- |
+| main.dart.js transfer size | _tbd_ | _tbd_ | _tbd_ | Capture via `wc -c` on build artifacts. |
+| Additional chunk transfer | _tbd_ | _tbd_ | _tbd_ | Include deferred part sizes. |
+| Lighthouse Performance | _tbd_ | _tbd_ | _tbd_ | Mobile config, throttled. |
+| First Contentful Paint | _tbd_ | _tbd_ | _tbd_ | Report from Lighthouse. |
+| Time to Interactive | _tbd_ | _tbd_ | _tbd_ | Report from Lighthouse. |
+| Total Blocking Time | _tbd_ | _tbd_ | _tbd_ | Report from Lighthouse. |
+| Speed Index | _tbd_ | _tbd_ | _tbd_ | Report from Lighthouse. |
+| Scroll FPS (feed) | _tbd_ | _tbd_ | _tbd_ | Capture via Flutter DevTools performance overlay. |

--- a/perf/before/README.md
+++ b/perf/before/README.md
@@ -1,0 +1,2 @@
+Baseline metrics to be captured once Flutter tooling is available. Run
+`tool/perf_measure.sh` before recording Lighthouse and FPS data.

--- a/perf/plan.md
+++ b/perf/plan.md
@@ -1,0 +1,39 @@
+# Flutter Web Performance Plan
+
+## Goals
+- Reduce initial JavaScript payload and perceived Time To Interactive (TTI).
+- Improve frame stability during scroll and entrance animations.
+- Establish reproducible profiling & reporting for Lighthouse and bundle size metrics.
+
+## Key Tactics
+1. **Build configuration**
+   - Enforce HTML renderer for static content to avoid CanvasKit wasm downloads unless explicitly required.
+   - Ship with `--pwa-strategy offline-first`, `--source-maps`, `--split-debug-info`, and icon tree shaking.
+   - Automate `flutter build web --analyze-size` and keep JSON under `perf/*/size/`.
+
+2. **Code-splitting & deferred loading**
+   - Defer non-critical home sections (publications, contributions, photos) using Dart deferred libraries and a lightweight loader widget.
+   - Keep hero content (intro card, app shell) eagerly loaded to minimize first paint.
+
+3. **Runtime efficiency**
+   - Cache asynchronous JSON loads and avoid spawning new network requests on each rebuild.
+   - Preload local asset snapshots and upgrade to remote content in the background.
+   - Add repaint boundaries where cards animate in to limit raster work.
+
+4. **Assets & fonts**
+   - Disable runtime font fetching so fonts are bundled and cacheable.
+   - Ensure text JSON assets are part of the build for offline-first behaviour.
+
+5. **Profiling workflow**
+   - Provide a repeatable `tool/perf_measure.sh` script that records bundle sizes, Lighthouse metrics, and FPS samples.
+   - Store raw reports under `perf/before/` and `perf/after/` with timestamped subfolders.
+
+## Expected Impact
+- ≥20% reduction to initial JS transfer thanks to deferred module splitting and renderer swap.
+- Faster FCP/TTI by avoiding blocking HTTP requests on first frame and using local JSON snapshots.
+- Smoother scrolling by isolating repaint workloads and eliminating redundant rebuild-triggered fetches.
+
+## Risks & Mitigations
+- Deferred libraries can delay card availability → provide skeleton placeholders and eager warm-up after first frame.
+- Local JSON snapshot may fall behind remote source → keep background refresh that replaces content when remote succeeds.
+- HTML renderer may reduce fidelity for advanced canvas effects → document how to revert to CanvasKit if required.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,6 +74,7 @@ flutter:
     - assets/images/egs/egs6.webp
     - assets/images/egs/egs7.webp
     - assets/images/egs/egs8.webp
+    - assets/texts/
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware.

--- a/tool/perf_measure.sh
+++ b/tool/perf_measure.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v flutter >/dev/null 2>&1; then
+  echo "flutter binary is required on PATH" >&2
+  exit 127
+fi
+
+CHANNEL_INFO=$(flutter --version)
+echo "Using Flutter: $CHANNEL_INFO"
+
+echo "Cleaning build..."
+flutter clean
+flutter pub get
+
+mkdir -p perf/before perf/after perf/symbols
+
+STAMP=$(date +"%Y%m%d-%H%M%S")
+OUT_DIR="perf/after/${STAMP}"
+mkdir -p "${OUT_DIR}" "${OUT_DIR}/size"
+
+cat >"${OUT_DIR}/environment.txt" <<ENV
+Flutter version:
+${CHANNEL_INFO}
+ENV
+
+flutter analyze | tee "${OUT_DIR}/analyze.log"
+flutter test -r expanded | tee "${OUT_DIR}/test.log"
+
+flutter build web \
+  --release \
+  --web-renderer html \
+  --source-maps \
+  --pwa-strategy offline-first \
+  --split-debug-info=perf/symbols \
+  --analyze-size \
+  --tree-shake-icons \
+  --dart-define=FLUTTER_WEB_AUTO_DETECT=false \
+  --output=build/web-html \
+  | tee "${OUT_DIR}/build.log"
+
+SIZE_DIR=$(find build -maxdepth 2 -name "*code-size-analysis*" -type d | head -n1)
+if [[ -n "${SIZE_DIR:-}" ]]; then
+  cp -R "${SIZE_DIR}" "${OUT_DIR}/size/"
+fi
+
+echo "Bundle sizes:" > "${OUT_DIR}/bundle_sizes.txt"
+if [[ -f build/web-html/main.dart.js ]]; then
+  wc -c build/web-html/main.dart.js >> "${OUT_DIR}/bundle_sizes.txt"
+fi
+find build/web-html -name '*.part.js' -print0 | xargs -0 -I{} wc -c {} >> "${OUT_DIR}/bundle_sizes.txt" || true
+
+echo "Run a release web server separately before invoking Lighthouse." >> "${OUT_DIR}/README.md"


### PR DESCRIPTION
## Summary
- document a repeatable performance plan and add scripts/report placeholders for before/after measurements
- defer non-critical home sections, add loading placeholders, and cache remote JSON content to improve first paint and smoothness
- lock down release build flags, disable runtime font fetching, and ensure structured data ships as assets for offline-first behaviour

## Testing
- not run (Flutter SDK unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd677c552083309b447fba92d77b04