### PR TITLE
Remove deprecated web bootstrap script

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -51,19 +51,6 @@
 
 </head>
 <body>
-  <!-- This script installs service_worker.js to provide PWA functionality to
-       application. For more information, see:
-       https://developers.google.com/web/fundamentals/primers/service-workers -->
-  <script>
-    window.addEventListener('load', function () {
-      if ('serviceWorker' in navigator) {
-        // Register the service worker but don't block the app bootstrap on it.
-        navigator.serviceWorker.register('flutter_service_worker.js').catch((error) => {
-          console.warn('Service worker registration failed:', error);
-        });
-      }
-    });
-  </script>
-  <script defer src="flutter_bootstrap.js"></script>
+  <script async src="flutter_bootstrap.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the manual service worker registration script from `web/index.html`
- rely on the generated `flutter_bootstrap.js` per current Flutter web template

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0e7e0af788330b3dd26712981c07f