### PR TITLE
Disable horizontal navigation gestures on web

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -38,6 +38,17 @@
 
   <title>Zengrui Jin</title>
   <link rel="manifest" href="manifest.json">
+  <style>
+    html,
+    body {
+      overscroll-behavior-x: none;
+    }
+
+    body,
+    #flt-glass-pane {
+      touch-action: pan-y;
+    }
+  </style>
 
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-4SJNNRFW4C"></script>


### PR DESCRIPTION
## Summary
- prevent browser swipe navigation from interfering with the carousel by disabling horizontal overscroll
- restrict touch actions to vertical panning for the main Flutter surface

## Testing
- not run (Flutter SDK not available in environment)

------
https://chatgpt.com/codex/tasks/task_e_68e5471af3c48330b055280574539c08